### PR TITLE
feat(errors): add error handler and recovery middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
+  name = "github.com/certifi/gocertifi"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "deb3ae2ef2610fde3330947281941c562861188b"
+  version = "2018.01.18"
+
+[[projects]]
   digest = "1:ed4582b92b69928dec6d82f78d1ad64863b89e631217bfdc5c63b3066a053eea"
   name = "github.com/creasty/defaults"
   packages = ["."]
@@ -16,6 +24,14 @@
   pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:d18f6f088d7d8365df47f49dfa24b6ff6701a941118ffda30c589d1bd954074b"
+  name = "github.com/getsentry/raven-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f04e7487e9a6b9d9837d52743fb5f40576c56411"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:2391a16d6bb332e406ba71d6102d520442e5b62514de3808078fb71f6e355c6d"
@@ -34,6 +50,25 @@
   pruneopts = "UT"
   revision = "003999b8cdeac09f13d183a7f5e1342d9a33a174"
   version = "v8.0.5"
+
+[[projects]]
+  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
+  name = "github.com/go-playground/locales"
+  packages = [
+    ".",
+    "currency",
+  ]
+  pruneopts = "UT"
+  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
+  version = "v0.12.1"
+
+[[projects]]
+  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
+  name = "github.com/go-playground/universal-translator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
+  version = "v0.16.0"
 
 [[projects]]
   digest = "1:bed9d72d596f94e65fff37f4d6c01398074a6bb1c3f3ceff963516bd01db6ff5"
@@ -69,6 +104,14 @@
   pruneopts = "UT"
   revision = "4919956f6fb227b548f004da27c7c6b20fba499f"
   version = "v0.3.0"
+
+[[projects]]
+  digest = "1:6782ffc812e8e700e6952ede1e60487ff1fd9da489eff762985be662a7cfc431"
+  name = "github.com/leodido/go-urn"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "70078a794e8ea4b497ba7c19a78cd60f90ccf0f4"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:8a4073008a71ff9009d35de4f9ef33bc8e814d79f284961bbbf8c5ae97fabad3"
@@ -129,6 +172,14 @@
   pruneopts = "UT"
   revision = "b806a5ecbe5347ad9ef05121fea8f4acc65fa5fc"
   version = "v1.15.0"
+
+[[projects]]
+  digest = "1:700753018409094bbf9b4e19ea0e147458b3aaadf677da3a44ec082d3c075506"
+  name = "github.com/segmentio/go-snakecase"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5e4a23e7a7bf2d4ede976046611e07ffba02224c"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:99d32780e5238c2621fff621123997c3e3cca96db8be13179013aea77dfab551"
@@ -211,6 +262,25 @@
   version = "v0.3.2"
 
 [[projects]]
+  digest = "1:dad6cd59e8bb8d209194efbd3850b5d054384a63061671bfc2a6b2cc0929c731"
+  name = "gopkg.in/go-playground/mold.v2"
+  packages = [
+    ".",
+    "modifiers",
+  ]
+  pruneopts = "UT"
+  revision = "6bc20ce40733e8e04c2fda4523a957dd8e198948"
+  version = "v2.2.0"
+
+[[projects]]
+  digest = "1:ffb045e56464a5f683830c7a8eec153d35c0444c77f6132bc531617ed58a94d2"
+  name = "gopkg.in/go-playground/validator.v9"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "556b9da3c05f2a935bc086fb5a0bb55dd8112d2d"
+  version = "v9.29.1"
+
+[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -231,14 +301,19 @@
   analyzer-version = 1
   input-imports = [
     "github.com/creasty/defaults",
+    "github.com/getsentry/raven-go",
     "github.com/go-pg/pg",
     "github.com/go-pg/pg/orm",
+    "github.com/gofrs/uuid",
     "github.com/labstack/echo",
     "github.com/lob/logger-go",
     "github.com/pkg/errors",
     "github.com/robinjoseph08/go-pg-migrations",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "gopkg.in/go-playground/mold.v2",
+    "gopkg.in/go-playground/mold.v2/modifiers",
+    "gopkg.in/go-playground/validator.v9",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,3 +48,7 @@
 [[constraint]]
   name = "github.com/creasty/defaults"
   version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/getsentry/raven-go"
+  version = "0.2.0"

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-pg/pg"
 	"github.com/nathankhuu/goyagi/pkg/config"
 	"github.com/nathankhuu/goyagi/pkg/database"
+	"github.com/nathankhuu/goyagi/pkg/sentry"
 	"github.com/pkg/errors"
 )
 
@@ -12,6 +13,7 @@ import (
 type App struct {
 	Config config.Config
 	DB     *pg.DB
+	Sentry sentry.Sentry
 }
 
 // New creates a new instance of App with a Config and DB connection.
@@ -23,5 +25,10 @@ func New() (App, error) {
 		return App{}, errors.Wrap(err, "application")
 	}
 
-	return App{cfg, db}, nil
+	sentry, err := sentry.New(cfg)
+	if err != nil {
+		return App{}, errors.Wrap(err, "application")
+	}
+
+	return App{cfg, db, sentry}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,20 +1,21 @@
 package config
 
 import (
-    "os"
+	"os"
 )
 
 // Config contains the environment specific configuration values needed by the
 // application.
 type Config struct {
-    DatabaseHost     string
-    DatabasePort     int
-    DatabaseName     string
-    DatabaseUser     string
-    DatabasePassword string
-    DatabaseTLS      bool
-    Environment      string
-    Port             int
+	DatabaseHost     string
+	DatabasePort     int
+	DatabaseName     string
+	DatabaseUser     string
+	DatabasePassword string
+	DatabaseTLS      bool
+	Environment      string
+	Port             int
+	SentryDSN        string
 }
 
 const environmentENV = "ENVIRONMENT"
@@ -22,22 +23,23 @@ const environmentENV = "ENVIRONMENT"
 // New returns an instance of Config based on the "ENVIRONMENT" environment
 // variable.
 func New() Config {
-    cfg := Config{
-        DatabaseHost:     os.Getenv("DATABASE_HOST"),
-        DatabasePort:     5432,
-        DatabaseName:     os.Getenv("DATABASE_NAME"),
-        DatabaseUser:     os.Getenv("DATABASE_USER"),
-        DatabasePassword: os.Getenv("DATABASE_PASSWORD"),
-        DatabaseTLS:      true,
-        Port:             3000,
-    }
+	cfg := Config{
+		DatabaseHost:     os.Getenv("DATABASE_HOST"),
+		DatabasePort:     5432,
+		DatabaseName:     os.Getenv("DATABASE_NAME"),
+		DatabaseUser:     os.Getenv("DATABASE_USER"),
+		DatabasePassword: os.Getenv("DATABASE_PASSWORD"),
+		DatabaseTLS:      true,
+		Port:             3000,
+		SentryDSN:        os.Getenv("SENTRY_DSN"),
+	}
 
-    switch os.Getenv(environmentENV) {
-    case "development", "":
-        loadDevelopmentConfig(&cfg)
-    case "test":
-        loadTestConfig(&cfg)
-    }
+	switch os.Getenv(environmentENV) {
+	case "development", "":
+		loadDevelopmentConfig(&cfg)
+	case "test":
+		loadTestConfig(&cfg)
+	}
 
-    return cfg
+	return cfg
 }

--- a/pkg/errors/handler.go
+++ b/pkg/errors/handler.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	"net/http"
+
+	"github.com/getsentry/raven-go"
+	"github.com/labstack/echo"
+	loggergo "github.com/lob/logger-go"
+	"github.com/nathankhuu/goyagi/pkg/application"
+	"github.com/nathankhuu/goyagi/pkg/logger"
+)
+
+type handler struct {
+	app application.App
+}
+
+// RegisterErrorHandler takes in an Echo router and registers routes onto it.
+func RegisterErrorHandler(e *echo.Echo, app application.App) {
+	h := handler{app}
+
+	e.HTTPErrorHandler = h.handleError
+}
+
+// handleError is an Echo error handler that uses HTTP errors accordingly, and any
+// generic error will be interpreted as an internal server error.
+func (h *handler) handleError(err error, c echo.Context) {
+	// Fetch the logger set into the echo.Context by the logger middleware.
+	// This logger has the request ID associated with this particular request.
+	log := logger.FromContext(c)
+
+	// Default our status code and message to a 500 error.
+	code := http.StatusInternalServerError
+	msg := http.StatusText(code)
+
+	// If we are bubbling up an HTTP error it must be because we specifically
+	// wanted to return this particular error and message. Set our status code
+	// and message to the ones specificed in the HTTP error.
+	if he, ok := err.(*echo.HTTPError); ok {
+		code = he.Code
+		msg = http.StatusText(code)
+	}
+
+	if code == http.StatusInternalServerError {
+		stacktrace := raven.NewException(err, raven.GetOrNewStacktrace(err, 0, 2, nil))
+		httpContext := raven.NewHttp(c.Request())
+		packet := raven.NewPacket(msg, stacktrace, httpContext)
+
+		h.app.Sentry.Client.Capture(packet, map[string]string{})
+	}
+
+	// Log our error with our child logger.
+	log.Root(loggergo.Data{"status_code": code}).Err(err).Error("request error")
+
+	// Return the error in the form of an HTTP response.
+	err = c.JSON(code, map[string]interface{}{"error": map[string]interface{}{"message": msg, "status_code": code}})
+	if err != nil {
+		log.Err(err).Error("error handler json error")
+	}
+}

--- a/pkg/errors/handler_test.go
+++ b/pkg/errors/handler_test.go
@@ -1,0 +1,85 @@
+package errors
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/getsentry/raven-go"
+	"github.com/labstack/echo"
+	"github.com/nathankhuu/goyagi/internal/test"
+	"github.com/nathankhuu/goyagi/pkg/application"
+	"github.com/nathankhuu/goyagi/pkg/sentry"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockSentryClient is a dummy struct that adheres to the ravenClient
+// interface defined by in our sentry package. This allows us to create a mock
+// client that has the same function signature but doesn't actually make a
+// request to Sentry when invoked. While we do not assert the values that get
+// passed into the function you can assert or fail tests based on the values
+// that get pased in to the mock client functions.
+type mockSentryClient struct{}
+
+func (m mockSentryClient) Capture(packet *raven.Packet, captureTags map[string]string) (string, chan error) {
+	return "", nil
+}
+
+func TestHandler(t *testing.T) {
+	app := application.App{
+		Sentry: sentry.Sentry{
+			Client: mockSentryClient{}, // set the mock client instead of a real raven client
+		},
+	}
+	h := handler{app}
+
+	t.Run("surfaces generic errors as internal server errors", func(tt *testing.T) {
+		c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+		err := errors.New("foo")
+
+		h.handleError(err, c)
+
+		assert.Equal(tt, http.StatusInternalServerError, rr.Code, "expected generic errors to be 500s")
+		assert.Contains(tt, rr.Body.String(), "Internal Server Error", "expected generic errors to have the correct message")
+	})
+
+	t.Run("surfaces HTTP errors transparently but obfuscates message", func(tt *testing.T) {
+		c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+		err := echo.NewHTTPError(http.StatusForbidden, "foo")
+
+		h.handleError(err, c)
+
+		assert.Equal(tt, http.StatusForbidden, rr.Code, "expected HTTP errors to be correct")
+		assert.Contains(tt, rr.Body.String(), "Forbidden", "expected HTTP errors to have the correct message")
+	})
+
+	t.Run("overwrites HTTP 400 error messages", func(tt *testing.T) {
+		c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+		err := echo.NewHTTPError(http.StatusBadRequest, "this shouldn't be sent to customers")
+
+		h.handleError(err, c)
+
+		assert.Equal(tt, http.StatusBadRequest, rr.Code, "expected HTTP errors to be correct")
+		assert.Contains(tt, rr.Body.String(), "Bad Request", "expected HTTP errors to have the correct message")
+	})
+
+	t.Run("overwrites HTTP 403 error messages", func(tt *testing.T) {
+		c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+		err := echo.NewHTTPError(http.StatusForbidden, "this shouldn't be sent to customers")
+
+		h.handleError(err, c)
+
+		assert.Equal(tt, http.StatusForbidden, rr.Code, "expected HTTP errors to be correct")
+		assert.Contains(tt, rr.Body.String(), "Forbidden", "expected HTTP errors to have the correct message")
+	})
+
+	t.Run("overwrites HTTP 404 error messages", func(tt *testing.T) {
+		c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+		err := echo.NewHTTPError(http.StatusNotFound, "this shouldn't be sent to customers")
+
+		h.handleError(err, c)
+
+		assert.Equal(tt, http.StatusNotFound, rr.Code, "expected HTTP errors to be correct")
+		assert.Contains(tt, rr.Body.String(), "Not Found", "expected HTTP errors to have the correct message")
+	})
+}

--- a/pkg/recovery/middleware.go
+++ b/pkg/recovery/middleware.go
@@ -1,0 +1,27 @@
+package recovery
+
+import (
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+)
+
+// Middleware recovers from any possible panics in subsequent handlers
+// and funnels it to the error handler to be returned as a 500.
+func Middleware() func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			defer func() {
+				// If for some reason we panic we can recover from it and
+				// invoke our error handler to handle the error surfaced by
+				// the panic.
+				if r := recover(); r != nil {
+					// Create an error based on the recovery panic message
+					err := errors.Errorf("%v", r)
+					// Invoke our error handler with the error created above
+					c.Error(err)
+				}
+			}()
+			return next(c)
+		}
+	}
+}

--- a/pkg/recovery/middleware_test.go
+++ b/pkg/recovery/middleware_test.go
@@ -1,0 +1,31 @@
+package recovery
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecovery(t *testing.T) {
+	e := echo.New()
+	e.Use(Middleware())
+
+	e.GET("/panic", func(c echo.Context) error {
+		panic(errors.New("panic test"))
+	})
+
+	req, err := http.NewRequest("GET", "/panic", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+
+	e.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "incorrect recovered status code")
+	assert.Contains(t, w.Body.String(), "Internal Server Error", "incorrect error message")
+}

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -1,0 +1,34 @@
+package sentry
+
+import (
+	"github.com/getsentry/raven-go"
+	"github.com/nathankhuu/goyagi/pkg/config"
+	"github.com/pkg/errors"
+)
+
+// RavenClient provides an interface for the Sentry client.
+type ravenClient interface {
+	Capture(packet *raven.Packet, captureTags map[string]string) (string, chan error)
+}
+
+// Sentry contains a client used to send exceptions to Sentry.io.
+// We are using an interface in our struct instead of the actual
+// client type in order to allow us to mock the clients behavior
+// in our tests.
+type Sentry struct {
+	Client ravenClient
+}
+
+// New returns an instance of Sentry.
+func New(cfg config.Config) (Sentry, error) {
+	defaultTags := map[string]string{
+		"environment": cfg.Environment,
+	}
+
+	client, err := raven.NewWithTags(cfg.SentryDSN, defaultTags)
+	if err != nil {
+		return Sentry{}, errors.Wrap(err, "sentry")
+	}
+
+	return Sentry{client}, nil
+}

--- a/pkg/sentry/sentry_test.go
+++ b/pkg/sentry/sentry_test.go
@@ -1,0 +1,18 @@
+package sentry
+
+import (
+	"testing"
+
+	"github.com/nathankhuu/goyagi/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	cfg := config.Config{
+		Environment: "test",
+	}
+	sentry, err := New(cfg)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, sentry)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,8 +9,10 @@ import (
 	"github.com/lob/logger-go"
 	"github.com/nathankhuu/goyagi/pkg/application"
 	"github.com/nathankhuu/goyagi/pkg/binder"
+	"github.com/nathankhuu/goyagi/pkg/errors"
 	"github.com/nathankhuu/goyagi/pkg/health"
 	"github.com/nathankhuu/goyagi/pkg/movies"
+	"github.com/nathankhuu/goyagi/pkg/recovery"
 	"github.com/nathankhuu/goyagi/pkg/signals"
 )
 
@@ -25,6 +27,11 @@ func New(app application.App) *http.Server {
 
 	// Register the logger middleware after we set our custom binder
 	e.Use(logger.Middleware())
+
+	// Register our recovery middleware after our logger middleware
+	e.Use(recovery.Middleware())
+
+	errors.RegisterErrorHandler(e, app)
 
 	health.RegisterRoutes(e)
 	movies.RegisterRoutes(e, app)


### PR DESCRIPTION
## What
Add error handler to manage errors and recovery middleware to ensure our application doesn't stop when a panic is received

## Why
To customize the way we return errors in HTTP responses and to log errors to Sentry to alert us and allow us to debug problems